### PR TITLE
Improve tool schema formatting, add tool call IDs, and enhance installer UX

### DIFF
--- a/agents/Dockerfile
+++ b/agents/Dockerfile
@@ -27,6 +27,10 @@ FROM node:20-bookworm-slim
 #                    via the persistent home). pipx solves competing dep
 #                    sets for skill-style installers (graphify, etc.)
 #   iptables, ipset, dnsutils, iproute2 — required by init-firewall.sh
+#   locales        — without it the container LANG defaults to POSIX, which
+#                    makes claude-code/opencode fall back to ASCII underscores
+#                    instead of Unicode box-drawing/indicator glyphs in the
+#                    TUI. Generated to C.UTF-8 below.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         tmux \
@@ -44,7 +48,17 @@ RUN apt-get update \
         ipset \
         dnsutils \
         iproute2 \
+        locales \
     && rm -rf /var/lib/apt/lists/*
+
+# Generate C.UTF-8 and export LANG/LC_ALL so every process inside the
+# container (entrypoint, gosu-launched harness user, tmux session, agent
+# CLIs) sees a UTF-8 locale. Use C.UTF-8 (not en_US.UTF-8) for portability:
+# no English-specific assumptions, just ASCII-compatible bytes plus UTF-8.
+RUN sed -i 's/^# *\(C.UTF-8\)/\1/' /etc/locale.gen \
+    && locale-gen C.UTF-8
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
 
 # Both agent CLIs at pinned versions. Bumping requires editing this file.
 ARG CLAUDE_CODE_VERSION=2.1.120

--- a/docs/WINDOWS.md
+++ b/docs/WINDOWS.md
@@ -94,6 +94,22 @@ git reset --hard
 
 This re-checks-out files with the .gitattributes rules applied. Should not be needed in practice.
 
+## Terminal font for Unicode rendering
+
+Claude-code and opencode use Unicode box-drawing and indicator characters
+in their TUI. Git Bash's default font (Lucida Console) has limited Unicode
+coverage. If you see underscores instead of box characters or icons, switch
+to a font with broader Unicode coverage:
+
+1. Right-click the MinTTY title bar
+2. Options → Text → Font → Select
+3. Pick "Cascadia Code", "Cascadia Mono", or "DejaVu Sans Mono"
+4. Apply
+
+The locale inside agent containers is set to C.UTF-8, so the rendering
+capability is there — only the host terminal font choice limits what
+displays correctly.
+
 ## Performance notes
 
 - Bind mounts to NTFS are slower than to Linux ext4. For performance-sensitive workloads, consider running harness inside WSL2 — but that's beyond the scope of this guide.

--- a/harness
+++ b/harness
@@ -589,16 +589,58 @@ cmd_start() {
     # Active MCPs sit behind the `mcp` profile so they're only brought up
     # when something has been `harness mcp enable`d. Without --profile they
     # are silently ignored even though the -f file is on the compose argv.
+    local up_rc=0
     if any_mcp_active; then
-        compose --profile mcp up -d "${build_flag[@]}"
+        compose --profile mcp up -d "${build_flag[@]}" || up_rc=$?
     else
-        compose up -d "${build_flag[@]}"
+        compose up -d "${build_flag[@]}" || up_rc=$?
+    fi
+
+    # When compose fails (typically a service container failing its
+    # healthcheck), print actionable diagnostics. Without this hint the
+    # user sees only "dependency failed to start: container ... is
+    # unhealthy" with no guidance on how to look inside.
+    if (( up_rc != 0 )); then
+        echo
+        echo "[harness] start failed (exit $up_rc). Common causes:"
+        echo "  - PROXY_API_URL or PROXY_API_KEY missing/wrong in .env"
+        echo "  - Upstream API hostname not in .harness-allowlist"
+        echo "  - Stale Docker resources (try: harness down)"
+        echo
+        echo "To diagnose, run:"
+        echo "  harness preflight                   # validates configuration"
+        echo "  docker logs harness-proxy-1         # what the proxy printed on startup"
+        echo "  docker logs harness-ollama-1        # what ollama printed on startup"
+        return $up_rc
     fi
 }
 
 cmd_down() {
     require_docker
-    compose down
+
+    # Stop any agent containers attached to this project's network. They were
+    # started by `harness claude`/`opencode` via direct docker run (not
+    # compose), so compose doesn't know about them — but they hold the
+    # network in use, blocking compose's network teardown and forcing the
+    # user to clean up by hand.
+    local agent_cids
+    agent_cids=$(docker ps -q \
+        --filter "label=harness.project=$project_name" \
+        --filter "label=harness.agent=true" 2>/dev/null)
+    if [[ -n "$agent_cids" ]]; then
+        local agent_names
+        agent_names=$(docker ps \
+            --filter "label=harness.project=$project_name" \
+            --filter "label=harness.agent=true" \
+            --format '{{.Names}}' | tr '\n' ' ')
+        echo "[harness] stopping agent containers: $agent_names"
+        # shellcheck disable=SC2086
+        docker stop $agent_cids >/dev/null 2>&1 || true
+        # shellcheck disable=SC2086
+        docker rm -f $agent_cids >/dev/null 2>&1 || true
+    fi
+
+    compose down "$@"
 }
 
 # Restart core services. Convenience for the common "I edited .env or
@@ -1120,6 +1162,7 @@ run_agent_interactive() {
         -v "$alp_host:/etc/harness/allowlist:ro"
         -w /workspace
         --label "harness.agent=true"
+        --label "harness.project=$project_name"
         --label "harness.tool=$tool"
         --label "harness.mount=$mount_path"
         "$image"

--- a/harness-install.sh
+++ b/harness-install.sh
@@ -24,7 +24,31 @@
 #   rm -rf <install-root>
 #   rm ~/.local/bin/harness
 
-set -euo pipefail
+# Detect whether we were sourced (so the PATH update inside this script
+# takes effect in the caller's shell) vs executed as a subprocess. Behavior
+# differs:
+#   - sourced:  do NOT enable `set -e`; it would terminate the user's
+#               interactive shell on any non-zero command in the rest of
+#               the script. Use `return` to leave the script.
+#   - executed: enable strict mode for installer safety; use `exit` normally.
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+    HARNESS_INSTALL_SOURCED=1
+else
+    HARNESS_INSTALL_SOURCED=0
+    set -euo pipefail
+fi
+
+# Helper: exit if executed, return if sourced. Without this, `source
+# harness-install.sh` (which the README recommends so PATH updates land in
+# the parent shell) would kill the calling shell on the first `exit`.
+exit_or_return() {
+    local code="${1:-0}"
+    if (( HARNESS_INSTALL_SOURCED )); then
+        return "$code"
+    else
+        exit "$code"
+    fi
+}
 
 # The default points at the public GitHub remote. scripts/full_pipeline_test.sh
 # overrides this via HARNESS_REPO_URL=<local-path> so the pipeline test can
@@ -50,7 +74,7 @@ fi
 
 ok()    { printf '%s✓%s %s\n'  "$C_GREEN"  "$C_RESET" "$*"; }
 warn()  { printf '%s!%s %s\n'  "$C_YELLOW" "$C_RESET" "$*"; }
-fail()  { printf '%sx%s %s\n'  "$C_RED"    "$C_RESET" "$*" >&2; exit 1; }
+fail()  { printf '%sx%s %s\n'  "$C_RED"    "$C_RESET" "$*" >&2; exit_or_return 1; }
 title() { printf '%s%s%s\n' "$C_BOLD" "$*" "$C_RESET"; }
 
 cwd=$(pwd)
@@ -200,7 +224,7 @@ preflight() {
     if (( errors > 0 )); then
         echo
         echo "[install] $errors check(s) failed. Resolve the issues above and re-run."
-        exit 1
+        exit_or_return 1
     fi
 
     echo "  all checks passed"
@@ -235,28 +259,12 @@ EOF
 
 preflight
 
-# --- CWD cleanliness check --------------------------------------------------
-#
-# Allow harness-install.sh, .env, README files, hidden dotfiles, and .git to
-# coexist (a user may pre-place a .env, or be running from inside a clone).
-# Anything else is suspicious — warn the user but don't block.
-
-allow_re='^(harness-install\.sh|\.env|README\.md|README\.txt|quickstart\.md|\..*)$'
-unexpected=$(ls -A . | grep -Ev "$allow_re" || true)
-if [[ -n "$unexpected" ]]; then
-    warn "current directory has unexpected entries:"
-    while IFS= read -r line; do
-        printf '    %s\n' "$line"
-    done <<<"$unexpected"
-    echo
-fi
-
 # --- prompts ----------------------------------------------------------------
 
 read -rp "continue? [y/N]: " ans
 case "${ans:-}" in
     y|Y|yes|YES) ;;
-    *) echo "aborted."; exit 0 ;;
+    *) echo "aborted."; exit_or_return 0 ;;
 esac
 
 read -rp "add 'harness' to PATH (recommended)? [Y/n]: " path_ans
@@ -464,24 +472,30 @@ Next:
 Available agents:
   harness claude
   harness opencode
-
-Auto-installed MCPs:
 EOF
 
-mcp_count=0
-if [[ -d "$install_root/state/mcp" ]]; then
-    for mcp_dir in "$install_root"/state/mcp/*/; do
-        [[ -f "$mcp_dir/harness-meta.json" ]] || continue
-        mcp_name=$(jq -r '.name // empty' "$mcp_dir/harness-meta.json" 2>/dev/null || true)
-        [[ -n "$mcp_name" ]] || mcp_name=$(basename "$mcp_dir")
-        mcp_enabled=$(jq -r '.enabled // empty' "$mcp_dir/harness-meta.json" 2>/dev/null || echo "?")
-        echo "  - $mcp_name (enabled: $mcp_enabled)"
+# Show what MCPs are present in the bundled registry, since none are
+# auto-installed by this script. Earlier the message said "Auto-installed
+# MCPs:" with a list pulled from state/mcp, which was always "(none)" on
+# a fresh install — misleading to users who took it as a status report
+# rather than an empty-by-design state.
+echo
+echo "MCPs available to install:"
+if [[ -d "$install_root/mcp-registry" ]]; then
+    mcp_count=0
+    for mcp_dir in "$install_root"/mcp-registry/*/; do
+        [[ -d "$mcp_dir" ]] || continue
+        name=$(basename "$mcp_dir")
+        echo "  - $name"
         mcp_count=$((mcp_count + 1))
     done
+    if (( mcp_count == 0 )); then
+        echo "  (none in registry)"
+    fi
 fi
-if (( mcp_count == 0 )); then
-    echo "  (none)"
-fi
+echo
+echo "To install one: harness mcp install <name>"
+echo "(see 'harness mcp list --available' for descriptions)"
 
 cat <<EOF
 
@@ -495,6 +509,10 @@ Manage MCPs:
 Need a shell inside an agent container (for installing skills, debugging)?
   harness shell
 
+If 'harness start' fails after configuration:
+  harness preflight                   # validates .env and allowlist
+  docker logs harness-proxy-1         # see what the proxy says
+
 Found a bug or have an improvement to suggest, however small?
   https://github.com/HandelSim/harness/issues
 
@@ -503,4 +521,4 @@ Uninstall harness:
   rm "\$HOME/.local/bin/harness"
 EOF
 
-exit 0
+exit_or_return 0

--- a/proxy/proxy.py
+++ b/proxy/proxy.py
@@ -19,6 +19,7 @@ import json
 import os
 import sys
 import traceback
+import uuid
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 import requests
@@ -84,6 +85,13 @@ def save_debug_file(req_id: str, stage_prefix: str, stage_name: str, payload: An
 # ---------------------------------------------------------------------------
 
 def format_tools_to_text(tools_array):
+    # Emit the full JSON Schema for each tool's parameters rather than a
+    # one-level summary. The earlier flattened format dropped nested
+    # object/array structure (e.g., opencode's `todowrite` with an array of
+    # {content, status, priority} objects), so the upstream LLM had no idea
+    # what fields to populate inside each item. JSON Schema is the lingua
+    # franca here — Claude and other capable models read it natively. Token
+    # cost goes up a few KB per request; correctness wins.
     if not tools_array:
         return "No tools available."
     schema_text = ""
@@ -91,26 +99,13 @@ def format_tools_to_text(tools_array):
         func = tool.get("function", {}) if "function" in tool else tool
         name = func.get("name", "unknown_tool")
         desc = func.get("description", "No description provided.")
-        schema_text += f"Tool Name: `{name}`\nDescription: {desc}\nParameters:\n"
-
         parameters = func.get("parameters", {})
-        properties = parameters.get("properties", {})
-        required_fields = parameters.get("required", [])
-
-        if not properties:
-            schema_text += "- None\n"
-        else:
-            for param_name, param_details in properties.items():
-                param_type = param_details.get("type", "string")
-                param_desc = param_details.get("description", "")
-
-                if param_name in required_fields:
-                    req_label = "**REQUIRED**"
-                else:
-                    req_label = "Optional"
-
-                schema_text += f"- `{param_name}` ({param_type}) [{req_label}]: {param_desc}\n"
-        schema_text += "\n"
+        schema_text += f"Tool Name: `{name}`\n"
+        schema_text += f"Description: {desc}\n"
+        schema_text += "Parameters (JSON Schema):\n"
+        schema_text += "```json\n"
+        schema_text += json.dumps(parameters, indent=2)
+        schema_text += "\n```\n\n"
     return schema_text.strip()
 
 
@@ -395,10 +390,19 @@ def generate_ndjson(
     if clean_text:
         yield json.dumps(make_chunk(model_name, content=clean_text)) + "\n"
     if tool_call_payload:
-        tc = [{"function": {
-            "name": tool_call_payload["name"],
-            "arguments": tool_call_payload["arguments"],
-        }}]
+        # An `id` is required so claude-code can later reference the
+        # tool_use block in conversation history. Without it the
+        # Anthropic-compatible upstream rejects the next turn with
+        # "tool_use block missing required 'id' field". The toolu_<24hex>
+        # format mirrors what real Anthropic returns.
+        tool_call_id = f"toolu_{uuid.uuid4().hex[:24]}"
+        tc = [{
+            "id": tool_call_id,
+            "function": {
+                "name": tool_call_payload["name"],
+                "arguments": tool_call_payload["arguments"],
+            },
+        }]
         yield json.dumps(make_chunk(model_name, tool_calls=tc)) + "\n"
     done_reason = "tool_calls" if tool_call_payload else "stop"
     yield json.dumps(make_chunk(model_name, done=True, done_reason=done_reason, usage=usage)) + "\n"

--- a/proxy/test_proxy.py
+++ b/proxy/test_proxy.py
@@ -22,7 +22,7 @@ class TestFormatTools(unittest.TestCase):
     def test_empty_array_returns_no_tools(self):
         self.assertEqual(proxy.format_tools_to_text([]), "No tools available.")
 
-    def test_required_and_optional_labels(self):
+    def test_top_level_schema_emitted(self):
         tools = [{
             "type": "function",
             "function": {
@@ -40,10 +40,98 @@ class TestFormatTools(unittest.TestCase):
         }]
         out = proxy.format_tools_to_text(tools)
         self.assertIn("get_weather", out)
-        self.assertIn("**REQUIRED**", out)
-        self.assertIn("Optional", out)
-        self.assertIn("`city`", out)
-        self.assertIn("`units`", out)
+        self.assertIn("city", out)
+        self.assertIn("units", out)
+        # JSON Schema's own required-array marks the required field.
+        self.assertIn('"required"', out)
+        self.assertIn('"city"', out)
+
+    def test_tool_call_emits_id_field(self):
+        """Tool calls in NDJSON output must include an 'id' field that downstream
+        Anthropic-compatible agents (claude-code) require for tool_use blocks."""
+        chunks = list(proxy.generate_ndjson(
+            model_name="test-model",
+            clean_text="",
+            tool_call_payload={"name": "Bash", "arguments": {"command": "ls"}},
+            usage={"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        ))
+        found_tc = False
+        for chunk_str in chunks:
+            chunk = json.loads(chunk_str)
+            msg = chunk.get("message", {})
+            tcs = msg.get("tool_calls")
+            if tcs:
+                found_tc = True
+                self.assertEqual(len(tcs), 1)
+                tc = tcs[0]
+                self.assertIn("id", tc, "tool_call must have 'id' field")
+                self.assertTrue(
+                    tc["id"].startswith("toolu_"),
+                    f"id should start with 'toolu_', got: {tc['id']}",
+                )
+                self.assertEqual(tc["function"]["name"], "Bash")
+        self.assertTrue(found_tc, "expected at least one chunk with tool_calls")
+
+    def test_tool_call_ids_are_unique(self):
+        """Two separate tool calls should get different ids."""
+        payload = {"name": "Bash", "arguments": {"command": "ls"}}
+        chunks1 = list(proxy.generate_ndjson("m", "", payload, {}))
+        chunks2 = list(proxy.generate_ndjson("m", "", payload, {}))
+
+        def get_id(chunks):
+            for c in chunks:
+                msg = json.loads(c).get("message", {})
+                tcs = msg.get("tool_calls")
+                if tcs:
+                    return tcs[0].get("id")
+            return None
+
+        id1 = get_id(chunks1)
+        id2 = get_id(chunks2)
+        self.assertIsNotNone(id1)
+        self.assertIsNotNone(id2)
+        self.assertNotEqual(id1, id2, "two tool calls should have unique ids")
+
+    def test_format_tools_includes_nested_schema(self):
+        """Tools with nested object/array parameters must have full schema in
+        the formatted output, not just top-level field names."""
+        tools = [{
+            "function": {
+                "name": "todowrite",
+                "description": "Write a todo list",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "todos": {
+                            "type": "array",
+                            "description": "The updated todo list",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "content": {"type": "string", "description": "Brief description"},
+                                    "status": {"type": "string", "description": "Current status"},
+                                    "priority": {"type": "string", "description": "Priority level"},
+                                },
+                                "required": ["content", "status", "priority"],
+                            },
+                        },
+                    },
+                    "required": ["todos"],
+                },
+            },
+        }]
+        text = proxy.format_tools_to_text(tools)
+        self.assertIn("todowrite", text)
+        self.assertIn("todos", text)
+        self.assertIn("content", text, "nested 'content' field missing from formatted tools")
+        self.assertIn("status", text, "nested 'status' field missing from formatted tools")
+        self.assertIn("priority", text, "nested 'priority' field missing from formatted tools")
+        self.assertIn("required", text, "nested required marker missing")
+
+    def test_format_tools_handles_empty_tools(self):
+        """Empty tools list returns the 'No tools available' message."""
+        self.assertEqual(proxy.format_tools_to_text([]), "No tools available.")
+        self.assertEqual(proxy.format_tools_to_text(None), "No tools available.")
 
 
 class TestExtractToolCall(unittest.TestCase):


### PR DESCRIPTION
## Summary
This PR makes several improvements to tool handling, installer robustness, and container configuration:

1. **Tool schema formatting**: Changed from a flattened parameter summary to emitting full JSON Schema, preserving nested object/array structure that LLMs need to correctly populate complex parameters.

2. **Tool call ID generation**: Added unique `id` fields to tool calls in NDJSON output (format: `toolu_<24hex>`), required by downstream Anthropic-compatible agents like claude-code.

3. **Installer improvements**: Made harness-install.sh safe to source (avoiding shell termination on errors), improved post-install messaging, and added diagnostic hints for startup failures.

4. **Container and CLI enhancements**: Fixed agent container cleanup in `harness down`, improved error messaging in `harness start`, and configured UTF-8 locale in agent containers for proper Unicode rendering.

## Key Changes

### proxy/proxy.py
- **format_tools_to_text()**: Now emits full JSON Schema for tool parameters instead of flattening to a one-level summary. This preserves nested structures (e.g., arrays of objects) that LLMs need to understand complex parameter requirements.
- **generate_ndjson()**: Added unique `id` field to tool_calls using UUID format `toolu_<24hex>`, required by claude-code for tool_use block references in conversation history.

### proxy/test_proxy.py
- Renamed test from `test_required_and_optional_labels` to `test_top_level_schema_emitted` to reflect new behavior
- Updated assertions to check for JSON Schema output (`"required"`, `"city"`) instead of markdown labels
- Added `test_tool_call_emits_id_field()`: Verifies tool calls include properly formatted `id` field
- Added `test_tool_call_ids_are_unique()`: Ensures separate tool calls get different IDs
- Added `test_format_tools_includes_nested_schema()`: Validates nested object/array parameters are preserved in formatted output
- Added `test_format_tools_handles_empty_tools()`: Tests None input handling

### harness-install.sh
- Added source vs. execute detection to safely support `source harness-install.sh` (recommended in README)
- Introduced `exit_or_return()` helper to avoid terminating user's shell when sourced
- Removed CWD cleanliness check that was overly strict for fresh installs
- Improved post-install messaging: changed "Auto-installed MCPs" (always empty on fresh install) to "MCPs available to install" showing bundled registry contents
- Added diagnostic hints for `harness start` failures and shell access

### harness
- **cmd_start()**: Captures compose exit code and prints actionable diagnostics when startup fails (missing .env vars, allowlist issues, stale resources)
- **cmd_down()**: Now stops and removes agent containers (labeled with `harness.agent=true`) before compose teardown, preventing network cleanup failures
- **run_agent_interactive()**: Added `harness.project=$project_name` label to agent containers for proper identification during cleanup

### agents/Dockerfile
- Added `locales` package to dependencies
- Generated C.UTF-8 locale and set `LANG=C.UTF-8` and `LC_ALL=C.UTF-8` environment variables
- Ensures claude-code/opencode render Unicode box-drawing characters correctly instead of falling back to ASCII underscores

### docs/WINDOWS.md
- Added section on terminal font configuration for proper Unicode rendering in Git Bash (recommends Cascadia Code, DejaVu Sans Mono)

## Notable Implementation Details
- Tool call IDs use `uuid.uuid4().hex[:24]` to match Anthropic's format while avoiding full UUID length overhead
- JSON Schema is emitted as a code block for readability while preserving full structure
- Installer safely handles both sourcing and execution paths without breaking user shells
- Agent container cleanup uses Docker labels for reliable identification across projects

https://claude.ai/code/session_01NbKU9MhSviBpAyMwHfbxfj