### PR TITLE
Print update banner in bold green so users notice it

### DIFF
--- a/harness
+++ b/harness
@@ -262,7 +262,9 @@ _show_update_banner_if_pending() {
     local_head=$(git -C "$install_root" rev-parse HEAD 2>/dev/null)
     [[ -n "$remote_head" && -n "$local_head" ]] || return 0
     [[ "$remote_head" == "$local_head" ]] && return 0
-    echo "[harness] update available; run 'harness upgrade' to update" >&2
+    # ANSI green (32) + bold (1), reset at end. Bold green stands out against
+    # most terminal themes (light + dark) and isn't reserved for errors.
+    printf '\033[1;32m[harness] update available; run '\''harness upgrade'\'' to update\033[0m\n' >&2
 }
 
 # Synchronous variant of the above for `harness check-updates`. Performs


### PR DESCRIPTION
The update-available banner was easy to miss because claude-code's TUI initialization clears the screen at startup, and the plain stderr text blended in. Bold green ANSI escape (\\033[1;32m) makes it stand out across light and dark terminal themes without using red (which is reserved for errors).