### PR TITLE
Convert system role to user role for upstreams that drop system

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,24 @@ PROXY_TIMEOUT=180
 #
 PROXY_PROMPT_MODE=user_front
 
+# Whether to convert the `system` role to `user` in the upstream request.
+# Some upstreams (notably some Gemini-compatible OpenAI-compat endpoints)
+# silently drop the system role. The model never sees claude-code's system
+# prompt — tool descriptions, environment context, CLAUDE.md content. The
+# failure is invisible (no error; the model just doesn't follow
+# system-level instructions).
+#
+# When 1 (default), the proxy converts any system message(s) at the head
+# of the conversation into a user message, then inserts a stub assistant
+# turn between the converted-system content and the actual first user
+# message. This satisfies upstreams that require strict role-alternation
+# (no two consecutive user messages).
+#
+# When 0, system messages pass through unchanged. Use 0 if you've
+# verified your upstream supports the system role end-to-end (test by
+# sending a system instruction and confirming the model follows it).
+PROXY_CHANGE_SYSTEM_PROMPT_TO_USER=1
+
 # ---------------------------------------------------------------------------
 # Proxy service (containers on the harness-net bridge)
 # ---------------------------------------------------------------------------

--- a/proxy/proxy.py
+++ b/proxy/proxy.py
@@ -75,6 +75,14 @@ _OUTPUT_DIR: Optional[str] = None  # set in main() before serving
 #                    as `system` for tool reliability.
 _PROMPT_MODE: str = "user_front"  # set in main() before serving
 
+# Some upstream APIs silently drop the `system` role. When set, this converts
+# the system message(s) into a user message at the start of the conversation,
+# with a stub assistant message between to satisfy strict role-alternation.
+# Default ON because the failure mode is invisible (the model just doesn't
+# follow system instructions and you may not notice). Set to "0" to disable
+# for upstreams that DO support system roles.
+_CHANGE_SYSTEM_TO_USER: bool = True
+
 
 # ---------------------------------------------------------------------------
 # OUTPUT_DIR handling
@@ -94,6 +102,13 @@ def _setup_prompt_mode() -> None:
         )
         raw = "user_front"
     _PROMPT_MODE = raw
+
+
+def _setup_change_system_to_user() -> None:
+    global _CHANGE_SYSTEM_TO_USER
+    raw = os.environ.get("PROXY_CHANGE_SYSTEM_PROMPT_TO_USER", "1").strip().lower()
+    _CHANGE_SYSTEM_TO_USER = raw not in ("0", "false", "no", "off", "")
+    print(f"[i] convert system to user: {_CHANGE_SYSTEM_TO_USER}", flush=True)
 
 
 def init_output_dir() -> Optional[str]:
@@ -633,6 +648,48 @@ def translate_history_and_apply_prompt(original_messages: List[Dict[str, Any]], 
                     messages[-1]["content"]
                 )
 
+    # Convert system role to user role if configured. Some upstream APIs
+    # silently drop the system role; this rewrites system content as a
+    # user message at the head of the conversation, with a stub assistant
+    # turn between it and the actual first user message to satisfy
+    # strict role-alternation requirements.
+    #
+    # Multiple system messages are already coalesced upstream into a
+    # single system message (see the `if role == "system"` branch above).
+    # By the time we reach here, there is at most ONE system message and
+    # it is at index 0 (if present at all).
+    if _CHANGE_SYSTEM_TO_USER and messages and messages[0]["role"] == "system":
+        system_content = messages[0]["content"]
+        # Some clients emit content as a list of content-blocks; flatten
+        # to a single string for the user-role rewrite.
+        if isinstance(system_content, list):
+            parts = []
+            for block in system_content:
+                if isinstance(block, dict):
+                    text = block.get("text", "")
+                    if text:
+                        parts.append(text)
+                elif isinstance(block, str):
+                    parts.append(block)
+            system_content = "\n\n".join(parts)
+        elif not isinstance(system_content, str):
+            system_content = str(system_content)
+        if system_content.strip():
+            # Replace the system message with a user message containing
+            # its content. Insert a stub assistant message after it so
+            # the next user message (the actual first user turn from the
+            # original conversation) doesn't violate strict alternation.
+            messages[0] = {"role": "user", "content": system_content}
+            if len(messages) > 1 and messages[1]["role"] == "user":
+                messages.insert(1, {
+                    "role": "assistant",
+                    "content": "I understand the instructions above.",
+                })
+        else:
+            # System message was empty/whitespace-only after normalization.
+            # Drop it entirely rather than producing an empty user message.
+            messages.pop(0)
+
     return messages
 
 
@@ -880,6 +937,7 @@ def main() -> None:
     _validate_config()
     _OUTPUT_DIR = init_output_dir()
     _setup_prompt_mode()
+    _setup_change_system_to_user()
 
     raw_output = os.environ.get("OUTPUT_DIR", "").strip()
     if not raw_output:
@@ -898,6 +956,7 @@ def main() -> None:
         f"   upstream key:   {_redact_key(PROXY_API_KEY)}\n"
         f"   timeout:        {PROXY_TIMEOUT}s\n"
         f"   prompt mode:    {_PROMPT_MODE}\n"
+        f"   sys→user:       {_CHANGE_SYSTEM_TO_USER}\n"
         f"   debug dumps:    {output_status}\n"
         "============================================================",
         flush=True,

--- a/proxy/test_proxy.py
+++ b/proxy/test_proxy.py
@@ -389,6 +389,14 @@ After block.'''
 
 
 class TestTranslateHistory(unittest.TestCase):
+    def setUp(self):
+        # These tests assert on the legacy role layout (system role passes
+        # through). Disable the new system→user conversion for the duration.
+        # The conversion has its own dedicated test class below.
+        p = patch.object(proxy, "_CHANGE_SYSTEM_TO_USER", False)
+        p.start()
+        self.addCleanup(p.stop)
+
     def test_empty_returns_empty(self):
         self.assertEqual(proxy.translate_history_and_apply_prompt([], ""), [])
 
@@ -543,6 +551,13 @@ class TestPromptInjectionModes(unittest.TestCase):
     """
 
     def setUp(self):
+        # These tests assert on the legacy role layout (system role passes
+        # through). The new system→user conversion is covered by
+        # TestChangeSystemToUser below.
+        p = patch.object(proxy, "_CHANGE_SYSTEM_TO_USER", False)
+        p.start()
+        self.addCleanup(p.stop)
+
         self.user_msgs = [
             {"role": "system", "content": "You are claude-code."},
             {"role": "user", "content": "say hello"},
@@ -696,6 +711,154 @@ class TestPromptInjectionModes(unittest.TestCase):
         self.assertIn("72F sunny", c)
         # The full per-turn user-mode scaffolding should NOT be present.
         self.assertNotIn("multi-step process", c)
+
+
+class TestChangeSystemToUser(unittest.TestCase):
+    """Tests for PROXY_CHANGE_SYSTEM_PROMPT_TO_USER. The conversion runs
+    AFTER prompt-mode injection and rewrites the head-of-conversation
+    system message as a user message, with a stub assistant turn between
+    it and the actual first user message."""
+
+    def test_change_system_to_user_converts_system_to_user(self):
+        """When PROXY_CHANGE_SYSTEM_PROMPT_TO_USER=1 and a system message
+        is present, it gets converted to a user message with a stub
+        assistant turn before the actual user message."""
+        with patch.object(proxy, "_CHANGE_SYSTEM_TO_USER", True):
+            with patch.object(proxy, "_PROMPT_MODE", "user_front"):
+                messages = [
+                    {"role": "system", "content": "You are claude-code."},
+                    {"role": "user", "content": "Hello"},
+                ]
+                result = proxy.translate_history_and_apply_prompt(messages, "")
+                self.assertEqual(len(result), 3)
+                self.assertEqual(result[0]["role"], "user")
+                self.assertEqual(result[0]["content"], "You are claude-code.")
+                self.assertEqual(result[1]["role"], "assistant")
+                self.assertEqual(result[1]["content"], "I understand the instructions above.")
+                self.assertEqual(result[2]["role"], "user")
+                self.assertIn("Hello", result[2]["content"])
+
+    def test_change_system_to_user_disabled_keeps_system(self):
+        """When PROXY_CHANGE_SYSTEM_PROMPT_TO_USER=0, system messages
+        pass through unchanged."""
+        with patch.object(proxy, "_CHANGE_SYSTEM_TO_USER", False):
+            with patch.object(proxy, "_PROMPT_MODE", "user_front"):
+                messages = [
+                    {"role": "system", "content": "You are claude-code."},
+                    {"role": "user", "content": "Hello"},
+                ]
+                result = proxy.translate_history_and_apply_prompt(messages, "")
+                self.assertEqual(len(result), 2)
+                self.assertEqual(result[0]["role"], "system")
+                self.assertEqual(result[0]["content"], "You are claude-code.")
+
+    def test_change_system_to_user_with_no_system_message(self):
+        """When there's no system message, conversion is a no-op."""
+        with patch.object(proxy, "_CHANGE_SYSTEM_TO_USER", True):
+            with patch.object(proxy, "_PROMPT_MODE", "user_front"):
+                messages = [
+                    {"role": "user", "content": "Hello"},
+                ]
+                result = proxy.translate_history_and_apply_prompt(messages, "")
+                self.assertEqual(len(result), 1)
+                self.assertEqual(result[0]["role"], "user")
+                # No stub assistant inserted; just the user message
+                for msg in result:
+                    self.assertNotEqual(msg["role"], "assistant")
+
+    def test_change_system_to_user_with_empty_system(self):
+        """When the system message is empty/whitespace, it's dropped
+        entirely rather than producing an empty user message."""
+        with patch.object(proxy, "_CHANGE_SYSTEM_TO_USER", True):
+            with patch.object(proxy, "_PROMPT_MODE", "user_front"):
+                messages = [
+                    {"role": "system", "content": "   \n  "},
+                    {"role": "user", "content": "Hello"},
+                ]
+                result = proxy.translate_history_and_apply_prompt(messages, "")
+                self.assertEqual(len(result), 1)
+                self.assertEqual(result[0]["role"], "user")
+
+    def test_change_system_to_user_concatenates_multiple_systems(self):
+        """Multiple system messages are coalesced (existing behavior)
+        then converted as a single combined user message."""
+        with patch.object(proxy, "_CHANGE_SYSTEM_TO_USER", True):
+            with patch.object(proxy, "_PROMPT_MODE", "user_front"):
+                messages = [
+                    {"role": "system", "content": "You are claude-code."},
+                    {"role": "system", "content": "Project: foo bar."},
+                    {"role": "user", "content": "Hello"},
+                ]
+                result = proxy.translate_history_and_apply_prompt(messages, "")
+                # Combined user + stub assistant + actual user = 3 messages
+                self.assertEqual(len(result), 3)
+                self.assertEqual(result[0]["role"], "user")
+                self.assertIn("You are claude-code.", result[0]["content"])
+                self.assertIn("Project: foo bar.", result[0]["content"])
+                self.assertIn("\n\n", result[0]["content"])  # the separator
+                self.assertEqual(result[1]["role"], "assistant")
+
+    def test_change_system_to_user_with_system_mode_injection(self):
+        """When PROMPT_MODE='system' AND CHANGE_SYSTEM_TO_USER is on, the
+        tool definitions get injected into the system message FIRST (by
+        the existing system-mode logic), then the loaded system message
+        gets converted to a user message. Tools end up in the converted
+        user message."""
+        with patch.object(proxy, "_CHANGE_SYSTEM_TO_USER", True):
+            with patch.object(proxy, "_PROMPT_MODE", "system"):
+                messages = [
+                    {"role": "system", "content": "You are claude-code."},
+                    {"role": "user", "content": "Hello"},
+                ]
+                tools_text = "Bash: Run shell command\nRead: Read a file"
+                result = proxy.translate_history_and_apply_prompt(messages, tools_text)
+                self.assertEqual(result[0]["role"], "user")
+                self.assertIn("You are claude-code.", result[0]["content"])
+                self.assertIn("Bash", result[0]["content"])
+                self.assertIn("Read a file", result[0]["content"])
+                self.assertEqual(result[1]["role"], "assistant")
+                self.assertEqual(result[2]["role"], "user")
+                self.assertEqual(result[2]["content"], "Hello")
+
+    def test_change_system_to_user_with_user_front_mode(self):
+        """When PROMPT_MODE='user_front' AND CHANGE_SYSTEM_TO_USER is on,
+        user_front injection still wraps the LAST user message with tools,
+        and the converted-from-system content sits at the head with the
+        stub assistant between."""
+        with patch.object(proxy, "_CHANGE_SYSTEM_TO_USER", True):
+            with patch.object(proxy, "_PROMPT_MODE", "user_front"):
+                messages = [
+                    {"role": "system", "content": "You are claude-code."},
+                    {"role": "user", "content": "Hello"},
+                ]
+                tools_text = "Bash: Run shell command"
+                result = proxy.translate_history_and_apply_prompt(messages, tools_text)
+                self.assertEqual(len(result), 3)
+                self.assertEqual(result[0]["role"], "user")
+                self.assertEqual(result[0]["content"], "You are claude-code.")
+                self.assertEqual(result[1]["role"], "assistant")
+                self.assertEqual(result[2]["role"], "user")
+                # user_front markers wrap the last user message
+                self.assertIn("<<<BEGIN_USER_REQUEST>>>", result[2]["content"])
+                self.assertIn("Hello", result[2]["content"])
+                self.assertIn("Bash", result[2]["content"])
+
+    def test_change_system_to_user_with_list_content(self):
+        """Some clients send system content as a list of content-blocks.
+        Conversion should flatten to a string."""
+        with patch.object(proxy, "_CHANGE_SYSTEM_TO_USER", True):
+            with patch.object(proxy, "_PROMPT_MODE", "user_front"):
+                messages = [
+                    {"role": "system", "content": [
+                        {"type": "text", "text": "Block 1"},
+                        {"type": "text", "text": "Block 2"},
+                    ]},
+                    {"role": "user", "content": "Hello"},
+                ]
+                result = proxy.translate_history_and_apply_prompt(messages, "")
+                self.assertEqual(result[0]["role"], "user")
+                self.assertIn("Block 1", result[0]["content"])
+                self.assertIn("Block 2", result[0]["content"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The user's upstream API silently drops the 'system' role — model output ignores all system instructions. Direct test ('respond with exactly X' as a system instruction) confirmed the model never sees system content. This means claude-code's massive system prompt (tool descriptions, environment context, CLAUDE.md) has been invisible to the upstream, which is why 'system' and 'hybrid' prompt modes silently failed in Phase 22.

Added PROXY_CHANGE_SYSTEM_PROMPT_TO_USER (default 1). When enabled, the proxy:
  - rewrites the head-of-conversation system message as a user message containing the same content
  - inserts a stub assistant message ('I understand the instructions above.') between the converted system content and the actual first user message, satisfying upstreams that require strict role-alternation
  - leaves empty/whitespace-only system messages out (no empty user message produced)
  - flattens list-content system messages to strings

Conversion runs AFTER existing prompt-mode injection so 'system' and 'hybrid' modes still inject tools into the system message first; conversion just rewrites the role afterward. The role name 'system mode' refers to where tools go (the bag of context preceding user turns), not whether the role literally stays as 'system' on the wire.

Set PROXY_CHANGE_SYSTEM_PROMPT_TO_USER=0 if your upstream supports the system role natively. Verify by sending a system message with an explicit instruction (e.g. 'respond with exactly Y') and checking whether the model follows it.