### PR TITLE
Fix #18: route upgrade Y/n prompt through /dev/tty

### DIFF
--- a/harness
+++ b/harness
@@ -964,6 +964,37 @@ cmd_update() {
     git pull --ff-only
 }
 
+# Y/n confirmation prompt for cmd_upgrade. Reads from /dev/tty by default
+# to insulate the prompt from any stdin/terminal residue left by upstream
+# subprocesses. On Windows Git Bash the harness_jq Docker fallback runs
+# `docker.exe -i` immediately before this prompt; docker.exe interacts
+# with the parent ConPTY and can leave the regular stdin in a state where
+# `read` from FD 0 hangs even when the user types a valid response.
+# Reading from /dev/tty bypasses that. Mirrors pick_agent's prompt.
+#
+# The trailing \r strip is defensive against MSYS line endings — same
+# motivation as the CR fixes elsewhere in this script.
+#
+# HARNESS_CONFIRM_FROM_STDIN=1 reads from FD 0 instead of /dev/tty; this
+# is a test hook only — production callers must leave it unset.
+#
+# Returns 0 to proceed, 1 to abort. Empty/y/Y/yes/YES proceed; anything
+# else aborts.
+_upgrade_confirm() {
+    local prompt="$1"
+    local ans
+    if [[ "${HARNESS_CONFIRM_FROM_STDIN:-0}" == "1" ]]; then
+        IFS= read -rp "$prompt" ans || ans=""
+    else
+        IFS= read -rp "$prompt" ans </dev/tty
+    fi
+    ans=${ans%$'\r'}
+    case "${ans:-}" in
+        ""|y|Y|yes|YES) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 cmd_upgrade() {
     local check_only=0
     local no_prompt=0
@@ -1059,12 +1090,10 @@ EOF
 
     if (( ! no_prompt )); then
         if [[ -t 0 ]]; then
-            local ans
-            read -rp "Apply these upgrade actions? [Y/n]: " ans
-            case "${ans:-}" in
-                ""|y|Y|yes|YES) ;;
-                *) echo "harness: aborted by user"; return 1 ;;
-            esac
+            if ! _upgrade_confirm "Apply these upgrade actions? [Y/n]: "; then
+                echo "harness: aborted by user"
+                return 1
+            fi
         else
             err "non-interactive shell; pass --no-prompt to apply without confirmation"
             exit 1
@@ -3496,4 +3525,9 @@ main() {
     esac
 }
 
-main "$@"
+# Allow tests to source this script for access to internal helpers (e.g.
+# _upgrade_confirm) without invoking main. Production execution always
+# falls through to main "$@".
+if [[ -z "${HARNESS_SOURCE_ONLY:-}" ]]; then
+    main "$@"
+fi

--- a/scripts/upgrade_test.sh
+++ b/scripts/upgrade_test.sh
@@ -491,6 +491,65 @@ echo user >"${T7_DIR}/tgt/data/user.txt"
 [[ "$(cat "${T7_DIR}/tgt/data/user.txt")" == "user" ]] || fail "T7: fallback did not preserve data/"
 ok "T7: rsync-fallback shell loop produces identical result"
 
+# === Test 8: cmd_upgrade Y/n confirmation helper =========================
+#
+# Issue #18: on Windows Git Bash, the upgrade prompt would hang on "n"
+# because the harness_jq Docker fallback (docker.exe -i) leaves the
+# parent shell's stdin in a broken state. The fix routes the prompt
+# through /dev/tty and strips a trailing \r. This test exercises the
+# helper's input-classification logic via the HARNESS_CONFIRM_FROM_STDIN
+# hook — /dev/tty isn't reliably available in CI, so we use the stdin
+# path here. The hook itself is the only production-visible difference
+# between the two paths; the answer-classification + \r-strip logic is
+# shared.
+
+echo
+echo "--- T8: _upgrade_confirm input classification ---"
+
+# Source harness with HARNESS_SOURCE_ONLY=1 to access the helper without
+# invoking main. Point HARNESS_INSTALL_ROOT at a fresh tmpdir so the script's
+# top-level .env / state-dir lookups see an empty install (no side effects).
+mkdir -p "${WORK}/t8-install"
+# shellcheck disable=SC1091
+HARNESS_SOURCE_ONLY=1 HARNESS_INSTALL_ROOT="${WORK}/t8-install" source "${REPO_ROOT}/harness"
+export HARNESS_CONFIRM_FROM_STDIN=1
+
+# Each case: (input, expected_rc, label)
+# rc=0 → proceed; rc=1 → abort.
+confirm_case() {
+    local input="$1" expected="$2" label="$3"
+    local rc=0
+    _upgrade_confirm "test? " <<<"$input" >/dev/null || rc=$?
+    [[ "$rc" == "$expected" ]] \
+        || fail "T8 [$label]: input=$(printf '%q' "$input") expected rc=$expected, got rc=$rc"
+}
+
+# Proceed cases.
+confirm_case ""    0 "empty (default Y)"
+confirm_case "y"   0 "y"
+confirm_case "Y"   0 "Y"
+confirm_case "yes" 0 "yes"
+confirm_case "YES" 0 "YES"
+
+# Abort cases.
+confirm_case "n"   1 "n"
+confirm_case "N"   1 "N"
+confirm_case "no"  1 "no"
+confirm_case "NO"  1 "NO"
+confirm_case "x"   1 "stray keystroke"
+
+# CR-stripping: 'n\r' (Git Bash CRLF input) must abort, not proceed.
+confirm_case $'n\r'   1 "n with trailing CR"
+confirm_case $'no\r'  1 "no with trailing CR"
+# 'y\r' must still proceed.
+confirm_case $'y\r'   0 "y with trailing CR"
+confirm_case $'yes\r' 0 "yes with trailing CR"
+# Bare CR (empty after strip) defaults to proceed.
+confirm_case $'\r'    0 "bare CR (empty after strip)"
+
+unset HARNESS_CONFIRM_FROM_STDIN
+ok "T8: _upgrade_confirm correctly classifies y/n inputs and strips CR"
+
 echo
 echo "============================================================"
 echo " UPGRADE TEST PASSED"


### PR DESCRIPTION
On Windows Git Bash, replying "n" to "Apply these upgrade actions?" would hang. Root cause: cmd_upgrade calls harness_jq twice immediately before the prompt, and when host jq is missing harness_jq falls through to `docker run -i ...`. On Git Bash docker.exe is a native Windows binary that interacts with the parent ConPTY; this leaves the regular stdin in a state where the next `read` from FD 0 can hang regardless of user input.

Fix mirrors the existing pick_agent precedent (harness:1744): route the prompt through /dev/tty so it's insulated from any stdin/terminal residue left by upstream subprocesses, and strip a trailing \r as a defensive measure for MSYS line endings (same motivation as commit e544f2f).

Refactored the prompt into a small _upgrade_confirm helper so the input-classification + CR-strip logic is unit-testable. Added a HARNESS_SOURCE_ONLY guard around `main "$@"` so tests can source the script without running main, and a HARNESS_CONFIRM_FROM_STDIN test hook on the helper.

scripts/upgrade_test.sh T8 covers each of "", y/Y/yes/YES, n/N/no/NO, stray keystrokes, and the CR-stripping cases (n\r, no\r, y\r, yes\r, bare \r).