### PR TITLE
Fix #53: wire e2e scenarios 03/05/06 to a mock upstream sidecar

### DIFF
--- a/architecture/tests.md
+++ b/architecture/tests.md
@@ -166,7 +166,11 @@ either branch (see `.github/workflows/ci.yml`):
   harness, persistence, mcp, firewall).
 - `pipeline` — `tests/full_pipeline_test.sh`.
 - `integration` — `HARNESS_RUN_SLOW=1 tests/integration_test.sh`.
-- `e2e` — `tests/e2e/run.sh` over every scenario.
+- `e2e` — `tests/e2e/run.sh` over every scenario. The job runs
+  `./harness start` with `PROXY_API_URL` pointed at `mockupstream`, then
+  runs `run.sh` with `HARNESS_E2E_MOCK_UPSTREAM=1` so it provisions a
+  `mock_upstream.py` sidecar on the harness network for the scenarios to
+  drive (see `tests/e2e/README.md`).
 - `scheme_contract` — `tests/scheme_contract_test.sh`.
 
 Benchmarks (`harness benchmark ...`) NEVER run in CI; they need an

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -210,3 +210,27 @@ These are why the API looks the way it does:
 | `HARNESS_E2E_SCENARIOS_DIR`    | Override scenarios directory.              | `tests/e2e/scenarios`                  |
 | `HARNESS_E2E_PATTERN`          | Bash glob filter on scenario basenames.    | (unset; matches everything)            |
 | `HARNESS_E2E_LOG_DIR`          | Directory for pipe-pane logs + transcripts.| `/tmp/harness-e2e-<epoch>`             |
+| `HARNESS_E2E_MOCK_UPSTREAM`    | `=1` makes `run.sh` start a `mockupstream` sidecar before the scenarios and remove it after (see "Upstream for scenarios"). | (unset; no sidecar) |
+| `HARNESS_PROJECT_NAME`         | Compose project whose `harness-net` the mock sidecar joins. | `harness` |
+
+## Upstream for scenarios
+
+Every scenario drives a full agent → ollama → proxy → upstream round trip,
+so the `proxy` service needs a real upstream to forward `/api/chat` to. The
+scenarios must stay deterministic and offline-capable, so that upstream is
+always `tests/mock_upstream.py`, never a real LLM.
+
+In CI the e2e job runs `./harness start` (which brings up `proxy` + `ollama`
+with `PROXY_API_URL=http://mockupstream:9000/...`) and then runs `run.sh`
+with `HARNESS_E2E_MOCK_UPSTREAM=1`. That flag makes `run.sh` start the
+shared `tests/mock_upstream.py` as a `mockupstream` sidecar on the harness
+network (via `test_start_mockupstream` from `tests/lib/test_helpers.sh`),
+wait for it healthy, run the scenarios, then remove it. `mockupstream` is a
+dotless intra-cluster name, so the proxy's firewall guardrail lets it
+through without an allowlist entry.
+
+Run it the same way locally:
+
+```bash
+HARNESS_E2E_MOCK_UPSTREAM=1 bash tests/e2e/run.sh
+```

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -74,6 +74,42 @@ echo "e2e scenarios: ${#scenarios[@]} found in $SCENARIOS_DIR"
 echo "e2e logs:      $LOG_DIR"
 echo
 
+# --- optional mock upstream sidecar ----------------------------------------
+#
+# The e2e scenarios drive a full agent -> ollama -> proxy -> upstream round
+# trip, so the proxy needs a real upstream to forward `/api/chat` to. When
+# HARNESS_E2E_MOCK_UPSTREAM=1 (set by the CI e2e job), bring up the shared
+# tests/mock_upstream.py as a sidecar on the harness network with the alias
+# `mockupstream`, and tear it down on exit. PROXY_API_URL must already point
+# at http://mockupstream:9000/... — the proxy reads it once at `harness
+# start`, before this runs (mockupstream is a dotless intra-cluster name, so
+# the proxy's firewall guardrail lets it through without an allowlist entry).
+# Local runs leave the var unset and use whatever upstream the operator's
+# .env configured.
+MOCK_CONTAINER=""
+cleanup_mock() {
+    [[ -n "$MOCK_CONTAINER" ]] || return 0
+    echo "e2e: removing mock upstream sidecar ($MOCK_CONTAINER)"
+    harness_docker rm -f "$MOCK_CONTAINER" >/dev/null 2>&1 || true
+}
+if [[ "${HARNESS_E2E_MOCK_UPSTREAM:-0}" == "1" ]]; then
+    REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    export REPO_ROOT
+    # shellcheck source=../lib/test_helpers.sh
+    source "$REPO_ROOT/tests/lib/test_helpers.sh"
+    e2e_project="${HARNESS_PROJECT_NAME:-harness}"
+    MOCK_CONTAINER="${e2e_project}-mockupstream-1"
+    trap cleanup_mock EXIT
+    echo "e2e: starting mock upstream sidecar ($MOCK_CONTAINER)"
+    test_start_mockupstream "$e2e_project"
+    if ! test_wait_for_container_healthy "$MOCK_CONTAINER" 90; then
+        echo "e2e: mock upstream sidecar did not become healthy within 90s" >&2
+        exit 1
+    fi
+    echo "e2e: mock upstream sidecar healthy"
+    echo
+fi
+
 total=${#scenarios[@]}
 failed=0
 xfailed=0

--- a/tests/e2e/scenarios/03-streaming-render.yaml
+++ b/tests/e2e/scenarios/03-streaming-render.yaml
@@ -1,12 +1,5 @@
 name: 03-streaming-render
 inventory_refs: [P051, P032, F043]
-expected_failure: true
-expected_failure_reason: "no mock upstream wired in CI; placeholder upstream 404s, proxy returns 502, claude-code v2.1.120 retries with backoff (up to 10 attempts) so the pane never stabilizes within the step timeout (#37)"
-# Once a mock upstream is wired (#37), drop the expected_failure marker
-# and tighten the assertions to verify real streamed deltas land in the
-# pane. Until then, this scenario cannot exercise the streaming render
-# path it was written for — claude-code's retry behavior makes the
-# error-path "accidental pass" non-deterministic.
 description: |
   Send a prompt that triggers a long mock streaming response. The TUI must
   render the streamed deltas cleanly — no escape-sequence artifacts, no

--- a/tests/e2e/scenarios/05-multiline-paste.yaml
+++ b/tests/e2e/scenarios/05-multiline-paste.yaml
@@ -1,10 +1,5 @@
 name: 05-multiline-paste
 inventory_refs: [F043, F051]
-# Tracked in #37. Same root cause as scenario 03: the post-paste Enter
-# triggers a real /api/chat call; the placeholder upstream 404s; proxy 502s;
-# wait_stable_ms times out waiting for the TUI to settle.
-expected_failure: true
-expected_failure_reason: "no mock upstream wired in CI; post-paste Enter triggers real /api/chat that placeholder upstream 404s (#37)"
 description: |
   Paste a multi-line block into the claude TUI via bracketed paste and
   verify the TUI treats it as ONE input (i.e. submitting once produces a

--- a/tests/e2e/scenarios/06-ctrl-c-cancel.yaml
+++ b/tests/e2e/scenarios/06-ctrl-c-cancel.yaml
@@ -1,11 +1,5 @@
 name: 06-ctrl-c-cancel
 inventory_refs: [P051, F043]
-# Tracked in #37. The Enter step triggers a real /api/chat call; the
-# placeholder upstream 404s; the proxy 502s; the TUI never starts streaming
-# so there's nothing to Ctrl-C against. Will pass once a mock upstream is
-# wired and the cancel path can actually exercise an in-flight stream.
-expected_failure: true
-expected_failure_reason: "no mock upstream wired in CI; cannot exercise mid-stream cancel against a placeholder upstream that 404s (#37)"
 description: |
   Start a long streaming response, send Ctrl-C mid-stream, verify the
   TUI cancels cleanly: no error spew, no hung state, prompt returns and


### PR DESCRIPTION
## Summary

CI-failure issue #53 (run [25874531806](https://github.com/HandelSim/harness/actions/runs/25874531806)). HandelSim approved **Option A** from the investigation comment: finish #37 by giving the e2e scenarios a real, deterministic upstream.

- `tests/e2e/run.sh` now provisions the shared `tests/mock_upstream.py` as a `mockupstream` sidecar on the harness network when `HARNESS_E2E_MOCK_UPSTREAM=1`, and removes it on exit (EXIT trap). Mirrors the `test_start_mockupstream` wiring already used by `integration_test.sh`.
- Dropped `expected_failure: true` from scenarios `03-streaming-render`, `05-multiline-paste`, `06-ctrl-c-cancel` so they run for real instead of XFAIL/XPASS-flapping.
- Updated `tests/e2e/README.md` and `architecture/tests.md`.

## ⚠️ Coupled `.github/workflows/ci.yml` change — must land with this PR

The GitHub App cannot push workflow files, so the `ci.yml` half of Option A is **not** in this branch. Without it, dropping the `expected_failure` markers makes 03/05/06 fail on `dev` CI. **Apply this diff to the branch (or to `dev` in the same push) when merging:**

```diff
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,12 +236,11 @@ jobs:
       # Bootstrap config so `./harness start` will bring the stack up.
-      # PROXY_API_URL must point at a host that is in the allowlist or the
-      # proxy's init-firewall.sh guardrail aborts the container with FATAL
-      # before the healthcheck ever runs. api.github.com is in the bundled
-      # .harness-allowlist.example, so use it as the placeholder — the
-      # proxy never actually calls it because the agents in the scenarios
-      # talk to ollama via the intra-cluster name, not the upstream URL.
+      # PROXY_API_URL points at the mockupstream sidecar that
+      # tests/e2e/run.sh provisions on the harness network (gated by
+      # HARNESS_E2E_MOCK_UPSTREAM=1, set on the run.sh step below). It is a
+      # dotless intra-cluster name, so the proxy's init-firewall.sh
+      # guardrail lets it through without an allowlist entry, and the
+      # scenarios get a real, deterministic upstream to drive.
       - name: Seed harness config
         run: |
           cp .env.example .env
-          sed -i 's|^PROXY_API_URL=.*|PROXY_API_URL=https://api.github.com|' .env
+          sed -i 's|^PROXY_API_URL=.*|PROXY_API_URL=http://mockupstream:9000/v1/chat/completions|' .env
           sed -i 's|^PROXY_API_KEY=.*|PROXY_API_KEY=ci-placeholder-key|' .env
           sed -i 's|^PROXY_API_MODEL=.*|PROXY_API_MODEL=ci-placeholder-model|' .env
@@ -346,6 +345,7 @@ jobs:
       - name: tests/e2e/run.sh
         env:
           DOCKER_BUILDKIT: "1"
           COMPOSE_DOCKER_CLI_BUILD: "1"
+          HARNESS_E2E_MOCK_UPSTREAM: "1"
         run: bash tests/e2e/run.sh
```

## Why this is safe

- The proxy's `init-firewall.sh` guardrail (lines 222-240) explicitly skips dotless hosts (`mockupstream`) — no allowlist entry needed.
- Proxy-up-first / mock-second ordering is fine: the proxy connects to upstream per-request, not at startup; `integration_test.sh` already relies on exactly this ordering.
- The mock returns the OpenAI-shaped JSON the proxy's `extract_assistant_content` parses; the proxy translates to NDJSON itself.

## Test plan

- [x] `bash -n tests/e2e/run.sh`
- [x] Edited scenarios still parse as YAML; `expected_failure` removed
- [x] Ran `run.sh` with `HARNESS_E2E_MOCK_UPSTREAM=1` against a throwaway scenario — sidecar starts, becomes healthy, scenario runs, EXIT trap removes the sidecar
- [x] `POST /v1/chat/completions` to the sidecar returns the proxy-contract response shape
- [ ] Full e2e job green in CI once the `ci.yml` diff above is applied (could not run the full harness stack locally — agent image build + claude-code is too expensive; verified every cheap link in the chain)

Closes #53. Finishes #37.

Generated with [Claude Code](https://claude.ai/code)